### PR TITLE
Ensure there are no links from unknown timezones.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": "2017"
+    "ecmaVersion": 2018
   },
   "env": {
     "es6": true,

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,13 @@ function filterData(tzdata, config, file) {
   const filteredData = moment.tz.filterLinkPack(
     {
       version: tzdata.version,
-      zones: newZonesData,
-      links: newLinksData.map(link => link.join('|')),
+      zones: newLinksData.reduce((zones, link) => {
+        const newEntry = { ...newZonesData.find(z => z.name === link[0]) };
+        newEntry.name = link[1];
+        zones.push(newEntry);
+        return zones;
+      }, newZonesData ),
+      links: [],
     },
     startYear,
     endYear

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -212,6 +212,17 @@ describe('usage', () => {
       const zoneCount = data.zones.length + data.links.length;
       assert(zoneCount === moment.tz.names().length);
     });
+
+    it("does not include links from undefined timezones", async () => {
+      const { data } = await buildWebpack({
+        startYear: 2000
+      });
+      for (const link of data.links) {
+        const from = link.split('|')[0];
+        const matchingZone = data.zones.find(zone => zone.startsWith(from));
+        assert.notEqual(matchingZone, undefined, `'${from}' not in zones`);
+      }
+    });
   });
 
   describe('caching', () => {


### PR DESCRIPTION
The plugin could generate packed files containing links from timezones that are themselves links. This is not well supported by `moment-timezone` and would result in runtime errors.

For example, the latest dataset in `moment-timezone` includes a link from `Europe/Prague` to `Europe/Bratislava`: `Europe/Prague|Europe/Bratislava`. Running the plugin with `{startYear: 2000}` would keep that link, even though `Europe/Prague` becomes a link itself (`Europe/Paris|Europe/Prague`). This would result in a runtime error in `moment-timezone`: `Moment Timezone has no data for Europe/Prague`.

This PR ensures that links are converted into full entries before running through `filterLinkPack`, which then correctly does the deduplication and linking. A test is included to ensure the fixed behaviour.