### PR TITLE
Fix data tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,26 @@ language: node_js
 script:
   - yarn run lint
   - yarn test
-node_js:
-  - "8"
-  - "10"
-  - "12"
+jobs:
+  include:
+    # Standard testing with newish version.
+    - os: linux
+      node_js: 8
+    - os: linux
+      node_js: 10
+    - os: linux
+      node_js: 12
+
+    # Windows support on Travis CI is experimental.
+    # The tests run just fine and the build exits with 0, but the job never
+    # seems to stop by itself and effectively hangs.
+    # - os: windows
+    #   node_js: 12
+
+    # Extra testing with an older version as a regression check.
+    - os: linux
+      node_js: 12
+      before_install:
+      - yarn add -D moment-timezone@0.5.0
+      env:
+        TEST_REGRESSION=true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,8 @@ const moment = require('moment-timezone');
 const MomentTimezoneDataPlugin = require('../src');
 const { buildWebpack, zoneNames, linkNames, transitionRange } = require('./utils');
 
+console.log(`--- Running tests with moment-timezone version ${moment.tz.version} ---`);
+
 describe('instantiation', () => {
   const cacheDir = findCacheDir({ name: 'moment-timezone-data-webpack-plugin' });
 
@@ -154,7 +156,9 @@ describe('usage', () => {
       const testZone = data.zones.find(zone => zone.startsWith('Australia/Sydney'));
       const { start, end } = transitionRange(testZone);
       assert(start.year() === 2030);
-      assert(end.year() >= 2100);
+      // This should be the real test once https://github.com/moment/moment-timezone/issues/768 is fixed
+      // assert(end.year() >= 2100);
+      assert(end.year() >= 2037);
     });
 
     it('filters data based on end year', async () => {
@@ -163,7 +167,9 @@ describe('usage', () => {
       });
       const testZone = data.zones.find(zone => zone.startsWith('Australia/Sydney'));
       const { start, end } = transitionRange(testZone);
-      assert(start.year() <= 1900);
+      // This should be the real test once https://github.com/moment/moment-timezone/issues/768 is fixed
+      // assert(start.year() <= 1900);
+      assert(start.year() <= 1920);
       assert(end.year() === 1980);
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2713,9 +2713,9 @@ moment-locales-webpack-plugin@^1.0.7:
     lodash.difference "^4.5.0"
 
 moment-timezone@^0.5.23:
-  version "0.5.25"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.25.tgz#a11bfa2f74e088327f2cd4c08b3e7bdf55957810"
-  integrity sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
+  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
This updates the tests to expect a more limited range of data, so that the tests stop failing when run against `moment-timezone` v0.5.26 or later.

Fixes #14 