### PR TITLE
Support country data for moment-timezone 0.5.28 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable public changes to this project will be documented in this file (the 
 Development-only changes (e.g. updates to `devDependencies`) will not be listed here, as they don’t affect the public API.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## _Unreleased_
+### Added
+- Support `countries` data for `moment-timezone` versions `0.5.28` and later (#22).
+    - Filter `countries` list based on matching zones.
+    - New `matchCountries` filtering option to select all zones for a given set of countries.
+
 ## 1.1.0 – 2019-06-17
 ### Added
 - New `cacheDir` option (PR #11 — thanks to @sgomes).

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2019 Gilmore Davidson <gilmoreorless@gmail.com>
+Copyright 2019-2020 Gilmore Davidson <gilmoreorless@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ This is a **plugin** for **webpack** which reduces **data** for **moment-timezon
 - [Examples](#examples)
     - [All zones, with a limited date range](#all-zones-with-a-limited-date-range)
     - [All data for a specific zone](#all-data-for-a-specific-zone)
+    - [All data for a specific country](#all-data-for-a-specific-country)
     - [Limited data for a set of zones (single regular expression)](#limited-data-for-a-set-of-zones-single-regular-expression)
     - [Limited data for a set of zones (array of values)](#limited-data-for-a-set-of-zones-array-of-values)
+    - [Limited data for a set of countries](#limited-data-for-a-set-of-countries)
 - [License](#license)
 
 ## Why is this needed?
@@ -45,12 +47,12 @@ What if you only need the default English locale, and time zone data for Austral
 
 Running webpack in production mode results in the following file sizes:
 
-| [Configuration](example/config) | Raw size | Gzipped |
-|---|---|---|
-| Default                 | 1164 KiB        | 105 KiB |
-| Strip locales           |  959 KiB (~82%) |  56 KiB (~53%) |
-| Strip tz data           |  265 KiB (~23%) |  69 KiB (~66%) |
-| Strip locales & tz data |   60 KiB (~5%)  |  20 KiB (~19%) |
+| [Configuration](example/config) | Raw size       | Gzipped       |
+| ------------------------------- | -------------- | ------------- |
+| Default                         | 1164 KiB       | 105 KiB       |
+| Strip locales                   | 959 KiB (~82%) | 56 KiB (~53%) |
+| Strip tz data                   | 265 KiB (~23%) | 69 KiB (~66%) |
+| Strip locales & tz data         | 60 KiB (~5%)   | 20 KiB (~19%) |
 
 (Testing done with `webpack@4.28.3`, `moment@2.23.0`, `moment-timezone@0.5.23`.)
 
@@ -67,7 +69,7 @@ For example, if you know **_for certain_** that your web site/application...
 2. ...will never deal with future dates & times beyond a certain point (e.g. details of a specific event).
     * It’s (relatively) safe to remove any data beyond that date (using the [`endYear` option][options]).
 3. ...will only deal with a fixed set of time zones (e.g. rendering times relative to a set of physical buildings in a single country).
-    * It’s safe to keep only the data required for those zones (using the [`matchZones` option][options]).
+    * It’s safe to keep only the data required for those zones (using the [`matchZones` and/or `matchCountries` options][options]).
 
 However, if you’re allowing users to choose their time zone preference — with no theoretical limit on the range of dates you’ll handle — then you’re going to need all the data you can get.
 
@@ -107,7 +109,7 @@ module.exports = {
 
 #### Plugin options
 
-There are three available options to filter the time zone data. **At least one option** must be provided.
+There are four available options to filter the time zone data. **At least one option** must be provided.
 
 * `startYear` _(integer)_ — Only include data from this year onwards.
 * `endYear` _(integer)_ — Only include data up to (and including) this year.
@@ -115,6 +117,15 @@ There are three available options to filter the time zone data. **At least one o
   * _string_ — Include only this zone name as an exact match (e.g. `'Australia/Sydney'`).
   * _regexp_ — Include zones with names matching the regular expression (e.g. `/^Australia\//`).
   * _array_ (of the above types) — Include zones matching any of the values of the array. Each value can be a string or a regular expression, which will be matched following the rules above.
+* `matchCountries` — Only include data for time zones associated with specific countries, as determined by Moment Timezone’s [`zonesForCountry()`][moment-tz-zfc] API. `matchCountries` works with [ISO 3166 2-letter country codes][iso3166], and can be any of these types:
+  * _string_ — Include zones for this country code as an exact match (e.g. `'AU'`).
+  * _regexp_ — Include zones for country code matching the regular expression (e.g. `/^A|NZ/`).
+  * _array_ (of the above types) — Include zones for country codes matching any of the values of the array. Each value can be a string or a regular expression, which will be matched following the rules above.
+
+**NOTE:** The `matchCountries` option will only work when used with `moment-timezone` version `0.5.28` or later. If this option is used with a non-compliant version of `moment-timezone`, an error will be thrown.
+
+All filtering options are **AND** (a.k.a. conjunction) filters — that is, they become more restrictive as each one is applied. Only zone data that match **all** the provided filters will be added to the final output.
+For this reason, it’s probably safer to provide only one of `matchZones` or `matchCountries`; providing both is allowed, but you may not get the results you expect.
 
 There is also one non-filtering option that can be provided to configure other behaviour.
 
@@ -150,6 +161,15 @@ const plugin = new MomentTimezoneDataPlugin({
 });
 ```
 
+### All data for a specific country
+
+```js
+const plugin = new MomentTimezoneDataPlugin({
+  // Includes 'Pacific/Auckland' and 'Pacific/Chatham'
+  matchCountries: 'NZ',
+});
+```
+
 ### Limited data for a set of zones (single regular expression)
 
 ```js
@@ -170,6 +190,16 @@ const plugin = new MomentTimezoneDataPlugin({
 });
 ```
 
+### Limited data for a set of countries
+
+```js
+const plugin = new MomentTimezoneDataPlugin({
+  matchCountries: ['US', 'CA'],
+  startYear: 2000,
+  endYear: 2030,
+});
+```
+
 ## License
 
 [MIT License © Gilmore Davidson](LICENSE)
@@ -182,8 +212,10 @@ const plugin = new MomentTimezoneDataPlugin({
 [badge-gk]:      https://greenkeeper.io/
 [badge-gk-img]:  https://badges.greenkeeper.io/gilmoreorless/moment-timezone-data-webpack-plugin.svg
 
+[iso3166]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [moment-tz]: https://momentjs.com/timezone/
 [moment-tz-filter]: http://momentjs.com/timezone/docs/#/data-utilities/filter-link-pack/
+[moment-tz-zfc]: https://momentjs.com/timezone/docs/#/using-timezones/getting-country-zones/
 [moment-webpack]: https://github.com/iamakulov/moment-locales-webpack-plugin
 [npm]: https://www.npmjs.com/
 [options]: #plugin-options

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "^7.0.1",
     "moment": "^2.23.0",
     "moment-locales-webpack-plugin": "^1.0.7",
-    "moment-timezone": "^0.5.23",
+    "moment-timezone": "^0.5.28",
     "power-assert": "^1.6.1",
     "webpack": "^4.28.3",
     "webpack-cli": "^3.2.0"

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -15,6 +15,29 @@ if (!RegExp.escape) {
 }
 
 /**
+ * A rough equivalent of Array.prototype.flatMap, which is Node >= 11 only.
+ * This isn't a spec-compliant polyfill, just a small helper for my
+ * specific use cases.
+ */
+function flatMap(arr, mapper) {
+  if (typeof arr.flatMap === 'function') {
+    return arr.flatMap(mapper);
+  }
+  let ret = [];
+  arr.forEach((...args) => {
+    let result = mapper.call(this, ...args);
+    if (Array.isArray(result)) {
+      for (let thing of result) {
+        ret.push(thing);
+      }
+    } else {
+      ret.push(result);
+    }
+  });
+  return ret;
+}
+
+/**
  * Create regexps for matching zone names.
  * Returns an array of regexps matching the values of `matchZones`:
  * - createZoneMatchers(string) => [RegExpToMatchString]
@@ -102,6 +125,7 @@ function cacheFile(tzdata, config, cacheDirPath) {
 module.exports = {
   pluginName,
   createZoneMatchers,
+  flatMap,
   cacheDir,
   cacheFile,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -56,7 +56,8 @@ function createZoneMatchers(matchZones) {
 function cacheKey(tzdata, config) {
   return JSON.stringify({
     version: tzdata.version,
-    zones: config.matchZones.toString(),
+    zones: String(config.matchZones),
+    countries: String(config.matchCountries),
     dates: [config.startYear, config.endYear],
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
-const { createZoneMatchers, cacheFile } = require('./helpers');
+const { createZoneMatchers, cacheFile, flatMap } = require('./helpers');
 
 function filterData(tzdata, config, file) {
   const moment = require('moment-timezone/moment-timezone-utils');
@@ -15,14 +15,16 @@ function filterData(tzdata, config, file) {
   if (matchCountries) {
     // TODO: Rename createZoneMatchers as it's more generic than that
     countryCodeMatchers = createZoneMatchers(matchCountries);
-    const countryZones = tzdata.countries
+    const countryCodes = tzdata.countries
       .map(country => country.split('|'))
       .filter(country =>
         countryCodeMatchers.find(matcher => matcher.test(country[0]))
-      )
-      .flatMap(country => country[1].split(' ').filter(zone =>
+      );
+    const countryZones = flatMap(countryCodes, country =>
+      country[1].split(' ').filter(zone =>
         matchers.find(matcher => matcher.test(zone))
-      ));
+      )
+    );
     countryZoneMatchers = createZoneMatchers(countryZones);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,6 @@ function filterData(tzdata, config, file) {
   let countryZoneMatchers = [/./];
 
   if (matchCountries) {
-    if (!momentHasCountries) {
-      throwInvalid(
-        'The matchCountries option can only work with moment-timezone 0.5.28 or later. ' +
-        `You're using moment-timezone version ${moment.tz.version}`
-      );
-    }
-
     // TODO: Rename createZoneMatchers as it's more generic than that
     countryCodeMatchers = createZoneMatchers(matchCountries);
     const countryZones = tzdata.countries
@@ -140,6 +133,14 @@ function validateOptions(options) {
   // At least one option required
   if (!usedFilteringOptions.length) {
     throwInvalid('Must provide at least one filtering option.');
+  }
+
+  // Don't allow matchCountries when the data doesn't support it
+  if (options.matchCountries !== undefined) {
+    const tzdata = require('moment-timezone/data/packed/latest.json');
+    if (!tzdata.countries) {
+      throwInvalid('The matchCountries option can only work with moment-timezone 0.5.28 or later.');
+    }
   }
 
   // Invalid years

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -145,6 +145,18 @@ describe('usage', () => {
       assert.deepEqual(zoneNames(data), ['America/La_Paz', 'Europe/Zurich']);
       assert.deepEqual(linkNames(data), ['Europe/Vaduz']);
     });
+
+    it('filters country data based on matching zones', async () => {
+      const { data } = await buildWebpack({
+        matchZones: /z$/,
+      });
+      assert.deepEqual(data.countries, [
+        'BO|America/La_Paz',
+        'CH|Europe/Zurich',
+        'DE|Europe/Zurich',
+        'LI|Europe/Zurich Europe/Vaduz',
+      ]);
+    });
   });
 
   describe('date options', () => {
@@ -237,6 +249,7 @@ describe('usage', () => {
       });
       const zoneCount = data.zones.length + data.links.length;
       assert(zoneCount === moment.tz.names().length);
+      assert(data.countries.length === moment.tz.countries().length);
     });
 
     it("does not include links from undefined timezones", async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,10 @@
-const assert = require('power-assert');
+const assert = require('assert');
 const del = require('del');
 const findCacheDir = require('find-cache-dir');
 const glob = require('glob');
 const moment = require('moment-timezone');
 const MomentTimezoneDataPlugin = require('../src');
-const { buildWebpack, zoneNames, linkNames, transitionRange } = require('./utils');
+const { buildWebpack, zoneNames, linkNames, countryCodes, transitionRange } = require('./utils');
 
 const momentHasCountries = typeof moment.tz.countries === 'function';
 
@@ -19,6 +19,7 @@ describe('instantiation', () => {
     assert.doesNotThrow(
       () => new MomentTimezoneDataPlugin({
         matchZones: /Europe/,
+        matchCountries: /ES|FR/,
         startYear: 2000,
         endYear: 2038,
         cacheDir: cacheDir,
@@ -30,14 +31,14 @@ describe('instantiation', () => {
   it('throws when called with no arguments', () => {
     assert.throws(
       () => new MomentTimezoneDataPlugin(),
-      'Must provide at least one filtering option.'
+      /Must provide at least one filtering option./
     );
   });
 
   it('throws when called with empty options', () => {
     assert.throws(
       () => new MomentTimezoneDataPlugin({}),
-      'Must provide at least one filtering option.'
+      /Must provide at least one filtering option./
     );
   });
 
@@ -56,6 +57,7 @@ describe('instantiation', () => {
       () => new MomentTimezoneDataPlugin({
         cacheDir: cacheDir,
       }),
+      /Must provide at least one filtering option./
     );
   });
 
@@ -64,7 +66,7 @@ describe('instantiation', () => {
       () => new MomentTimezoneDataPlugin({
         startYear: 'string'
       }),
-      'Invalid option — startYear must be an integer.'
+      /Invalid option — startYear must be an integer./
     );
   });
 
@@ -74,6 +76,7 @@ describe('instantiation', () => {
         matchZones: /Europe/,
         cacheDir: 1,
       }),
+      /Provided cacheDir is an invalid path: '1'/
     );
   });
 });
@@ -163,6 +166,93 @@ describe('usage', () => {
         ]);
       });
     }
+  });
+
+  describe('matchCountries option', () => {
+    if (momentHasCountries) {
+      it('filters zones for a country matching a single string (exact match)', async () => {
+        const { data } = await buildWebpack({
+          matchCountries: 'BA',
+        });
+        assert.deepEqual(countryCodes(data), ['BA']);
+        assert.deepEqual(zoneNames(data), ['Europe/Belgrade']);
+        assert.deepEqual(linkNames(data), ['Europe/Sarajevo']);
+      });
+
+      it("returns no zones when a single string argument doesn't match any country", async () => {
+        const { data } = await buildWebpack({
+          matchCountries: 'ZX',
+        });
+        assert.ok(countryCodes(data).length === 0);
+        assert.ok(zoneNames(data).length === 0);
+        assert.ok(linkNames(data).length === 0);
+      });
+
+      it('filters zones for a country matching a single regexp', async () => {
+        const { data } = await buildWebpack({
+          matchCountries: /^Z/,
+        });
+        assert.deepEqual(countryCodes(data), ['ZA', 'ZM', 'ZW']);
+        assert.deepEqual(zoneNames(data), ['Africa/Johannesburg', 'Africa/Maputo']);
+        assert.deepEqual(linkNames(data), ['Africa/Harare', 'Africa/Lusaka']);
+      });
+
+      it('filters zones for countries matching an array of strings (exact match)', async () => {
+        const { data } = await buildWebpack({
+          // 'A' should not do any partial matching of codes
+          matchCountries: ['MO', 'CH', 'A'],
+        });
+        assert.deepEqual(countryCodes(data), ['CH', 'MO']);
+        assert.deepEqual(zoneNames(data), ['Asia/Macau', 'Europe/Zurich']);
+        assert.ok(linkNames(data).length === 0);
+      });
+
+      it('filters zones for countries matching an array of regexps', async () => {
+        const { data } = await buildWebpack({
+          matchCountries: [/^q/i, /D[AEIOU]/],
+        });
+        assert.deepEqual(countryCodes(data), ['DE', 'DO', 'QA']);
+        assert.deepEqual(zoneNames(data), [
+          'America/Santo_Domingo', 'Asia/Qatar',
+          'Europe/Berlin', 'Europe/Zurich',
+        ]);
+        assert.deepEqual(linkNames(data), ['Europe/Busingen']);
+      });
+
+      it('filters zones for countries matching an array of mixed values', async () => {
+        const { data } = await buildWebpack({
+          matchCountries: [/B$/, 'AZ'],
+        });
+        assert.deepEqual(countryCodes(data), ['AZ', 'BB', 'GB', 'LB', 'SB']);
+        assert.deepEqual(zoneNames(data), [
+          'America/Barbados', 'Asia/Baku', 'Asia/Beirut',
+          'Europe/London', 'Pacific/Guadalcanal',
+        ]);
+        assert.ok(linkNames(data).length === 0);
+      });
+
+      it('returns only zones matching matchCountries AND matchZones', async () => {
+        const { data } = await buildWebpack({
+          matchCountries: 'AU',
+          matchZones: /\/\w{5}$/, // 5-letter city name
+        });
+        assert.deepEqual(countryCodes(data), ['AU']);
+        assert.deepEqual(zoneNames(data), ['Australia/Eucla', 'Australia/Perth']);
+        assert.ok(linkNames(data).length === 0);
+      });
+    }
+
+    // TODO: How to mimic data loading failure in this test?
+    it.skip('throws when using matchCountries and moment-timezone has no country data', () => {
+      assert.throws(
+        async () => {
+          await buildWebpack({
+            matchCountries: 'AU',
+          });
+        },
+        /The 'matchCountries' option can only work with moment-timezone 0.5.28 or later./
+      );
+    });
   });
 
   describe('date options', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -58,6 +58,10 @@ function linkNames(packedData) {
   return getPackedNames(packedData.links, 1);
 }
 
+function countryCodes(packedData) {
+  return getPackedNames(packedData.countries, 0);
+}
+
 function transitionRange(packedZone) {
   const { name, untils } = moment.tz.unpack(packedZone);
   if (!untils.length) {
@@ -79,5 +83,6 @@ module.exports = {
   buildWebpack,
   zoneNames,
   linkNames,
+  countryCodes,
   transitionRange,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,7 +2712,7 @@ moment-locales-webpack-plugin@^1.0.7:
   dependencies:
     lodash.difference "^4.5.0"
 
-moment-timezone@^0.5.23:
+moment-timezone@^0.5.28:
   version "0.5.28"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
   integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==


### PR DESCRIPTION
- Filter `countries` list based on matching zones, when that data is available.
- New `matchCountries` filtering option to select all zones for a given set of countries.

Fixes #22 