### PR TITLE
Performance fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "prebuild:example": "rm -rf example/dist/*",
     "build:example": "cd example && for cfg in config/webpack.config.*.js; do webpack --config $cfg; done && gzip --keep --force dist/*.js",
     "lint": "eslint example src test",
-    "test": "mocha --require intelli-espower-loader test/*.test.js"
+    "test": "mocha --require intelli-espower-loader test/*.test.js",
+    "test:performance": "node test/performance.js"
   },
   "dependencies": {
     "find-cache-dir": "^3.0.0",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -37,14 +37,30 @@ function flatMap(arr, mapper) {
 }
 
 /**
+ * Get all unique values in an array or string.
+ * unique([1, 2, 3, 1, 5, 2, 4]) -> [1, 2, 3, 5, 4]
+ * unique('this is a string') -> ['t', 'h', 'i', 's', ' ', 'a', 'r', 'n', 'g']
+ */
+function unique(items) {
+  if (!Array.isArray(items) && typeof items !== 'string') {
+    return [];
+  }
+  return Array.from(new Set(items));
+}
+
+/**
  * Create regexps for matching zone names.
  * Returns an array of regexps matching the values of `matchZones` or `matchCountries`:
+ * - createMatchers(undefined) => []
  * - createMatchers(string) => [RegExpToMatchString]
  * - createMatchers(RegExp) => [RegExp]
  * - createMatchers([RegExp, RegExp, ...]) => [RegExp, RegExp, ...]
  * - createMatchers([string, string, ...]) => [RegExpMatchingAllStrings]
  */
 function createMatchers(matchItems) {
+  if (!matchItems) {
+    return [];
+  }
   const exactRegExp = (pattern) => new RegExp('^(?:' + pattern + ')$');
   const arrayRegExp = (arr) => exactRegExp(
     arr.map(value =>
@@ -142,6 +158,7 @@ function cacheFile(tzdata, config, cacheDirPath) {
 module.exports = {
   pluginName,
   flatMap,
+  unique,
   createMatchers,
   anyMatch,
   cacheDir,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -75,6 +75,24 @@ function createMatchers(matchItems) {
   return [exactRegExp(RegExp.escape(matchItems.toString()))];
 }
 
+/**
+ * Return `true` if `item` matches any of the RegExps in an array of matchers.
+ * If optional `extraMatchers` array is provided, `item` must match BOTH sets of matchers.
+ * If either array is empty, it's counted as matching everything.
+ */
+function anyMatch(item, regExpMatchers, extraMatchers) {
+  if (extraMatchers !== undefined) {
+    return (
+      anyMatch(item, regExpMatchers) &&
+      anyMatch(item, extraMatchers)
+    );
+  }
+  if (!regExpMatchers || !regExpMatchers.length) {
+    return true;
+  }
+  return regExpMatchers.some(matcher => matcher.test(item));
+}
+
 function cacheKey(tzdata, config) {
   return JSON.stringify({
     version: tzdata.version,
@@ -123,8 +141,9 @@ function cacheFile(tzdata, config, cacheDirPath) {
 
 module.exports = {
   pluginName,
-  createMatchers,
   flatMap,
+  createMatchers,
+  anyMatch,
   cacheDir,
   cacheFile,
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -51,7 +51,7 @@ function unique(items) {
 /**
  * Create regexps for matching zone names.
  * Returns an array of regexps matching the values of `matchZones` or `matchCountries`:
- * - createMatchers(undefined) => []
+ * - createMatchers(undefined) => [/.?/]
  * - createMatchers(string) => [RegExpToMatchString]
  * - createMatchers(RegExp) => [RegExp]
  * - createMatchers([RegExp, RegExp, ...]) => [RegExp, RegExp, ...]
@@ -59,7 +59,8 @@ function unique(items) {
  */
 function createMatchers(matchItems) {
   if (!matchItems) {
-    return [];
+    // For invalid input, return a RegExp that matches anything
+    return [/.?/];
   }
   const exactRegExp = (pattern) => new RegExp('^(?:' + pattern + ')$');
   const arrayRegExp = (arr) => exactRegExp(
@@ -72,7 +73,7 @@ function createMatchers(matchItems) {
     return [matchItems];
   }
   if (Array.isArray(matchItems)) {
-    const hasRegExp = matchItems.find(mz => mz instanceof RegExp);
+    const hasRegExp = matchItems.some(mz => mz instanceof RegExp);
     // Quick shortcut — combine array of strings into a single regexp
     if (!hasRegExp) {
       return [arrayRegExp(matchItems)];

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -16,8 +16,7 @@ if (!RegExp.escape) {
 
 /**
  * A rough equivalent of Array.prototype.flatMap, which is Node >= 11 only.
- * This isn't a spec-compliant polyfill, just a small helper for my
- * specific use cases.
+ * This isn't a spec-compliant polyfill, just a small helper for my specific use cases.
  */
 function flatMap(arr, mapper) {
   if (typeof arr.flatMap === 'function') {
@@ -39,13 +38,13 @@ function flatMap(arr, mapper) {
 
 /**
  * Create regexps for matching zone names.
- * Returns an array of regexps matching the values of `matchZones`:
- * - createZoneMatchers(string) => [RegExpToMatchString]
- * - createZoneMatchers(RegExp) => [RegExp]
- * - createZoneMatchers([RegExp, RegExp, ...]) => [RegExp, RegExp, ...]
- * - createZoneMatchers([string, string, ...]) => [RegExpMatchingAllStrings]
+ * Returns an array of regexps matching the values of `matchZones` or `matchCountries`:
+ * - createMatchers(string) => [RegExpToMatchString]
+ * - createMatchers(RegExp) => [RegExp]
+ * - createMatchers([RegExp, RegExp, ...]) => [RegExp, RegExp, ...]
+ * - createMatchers([string, string, ...]) => [RegExpMatchingAllStrings]
  */
-function createZoneMatchers(matchZones) {
+function createMatchers(matchItems) {
   const exactRegExp = (pattern) => new RegExp('^(?:' + pattern + ')$');
   const arrayRegExp = (arr) => exactRegExp(
     arr.map(value =>
@@ -53,19 +52,19 @@ function createZoneMatchers(matchZones) {
     ).join('|')
   );
 
-  if (matchZones instanceof RegExp) {
-    return [matchZones];
+  if (matchItems instanceof RegExp) {
+    return [matchItems];
   }
-  if (Array.isArray(matchZones)) {
-    const hasRegExp = matchZones.find(mz => mz instanceof RegExp);
+  if (Array.isArray(matchItems)) {
+    const hasRegExp = matchItems.find(mz => mz instanceof RegExp);
     // Quick shortcut — combine array of strings into a single regexp
     if (!hasRegExp) {
-      return [arrayRegExp(matchZones)];
+      return [arrayRegExp(matchItems)];
     }
     // Find all string values and combine them
     let ret = [];
     let strings = [];
-    matchZones.forEach(mz => {
+    matchItems.forEach(mz => {
       (mz instanceof RegExp ? ret : strings).push(mz);
     });
     if (strings.length) {
@@ -73,7 +72,7 @@ function createZoneMatchers(matchZones) {
     }
     return ret;
   }
-  return [exactRegExp(RegExp.escape(matchZones.toString()))];
+  return [exactRegExp(RegExp.escape(matchItems.toString()))];
 }
 
 function cacheKey(tzdata, config) {
@@ -124,7 +123,7 @@ function cacheFile(tzdata, config, cacheDirPath) {
 
 module.exports = {
   pluginName,
-  createZoneMatchers,
+  createMatchers,
   flatMap,
   cacheDir,
   cacheFile,

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,19 @@
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
-const { createZoneMatchers, cacheFile, flatMap } = require('./helpers');
+const { createMatchers, cacheFile, flatMap } = require('./helpers');
 
 function filterData(tzdata, config) {
   const moment = require('moment-timezone/moment-timezone-utils');
   const momentHasCountries = Boolean(tzdata.countries); // moment-timezone >= 0.5.28
   const { matchZones, matchCountries, startYear, endYear } = config;
 
-  let matchers = createZoneMatchers(matchZones);
+  let matchers = createMatchers(matchZones);
   let countryCodeMatchers = [/./];
   let countryZoneMatchers = [/./];
 
   if (matchCountries) {
-    // TODO: Rename createZoneMatchers as it's more generic than that
-    countryCodeMatchers = createZoneMatchers(matchCountries);
+    countryCodeMatchers = createMatchers(matchCountries);
     const countryCodes = tzdata.countries
       .map(country => country.split('|'))
       .filter(country =>
@@ -25,7 +24,7 @@ function filterData(tzdata, config) {
         matchers.find(matcher => matcher.test(zone))
       )
     );
-    countryZoneMatchers = createZoneMatchers(countryZones);
+    countryZoneMatchers = createMatchers(countryZones);
   }
 
   // Find all links that match anything in the matcher list.
@@ -39,8 +38,8 @@ function filterData(tzdata, config) {
 
   // If links exist, add the links’ destination zones to the matcher list.
   if (newLinksData.length) {
-    // TODO: De-duplicate the list of link sources before passing to createZoneMatchers
-    let linkMatchers = createZoneMatchers(
+    // TODO: De-duplicate the list of link sources before passing to createMatchers
+    let linkMatchers = createMatchers(
       newLinksData.map(link => link[0])
     );
     matchers = matchers.concat(linkMatchers);

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 const { createZoneMatchers, cacheFile, flatMap } = require('./helpers');
 
-function filterData(tzdata, config, file) {
+function filterData(tzdata, config) {
   const moment = require('moment-timezone/moment-timezone-utils');
   const momentHasCountries = Boolean(tzdata.countries); // moment-timezone >= 0.5.28
   const { matchZones, matchCountries, startYear, endYear } = config;
@@ -101,7 +101,7 @@ function filterData(tzdata, config, file) {
     startYear,
     endYear
   );
-  fs.writeFileSync(file.path, JSON.stringify(filteredData, null, 2));
+  return filteredData;
 }
 
 function throwInvalid(message) {
@@ -180,7 +180,8 @@ function MomentTimezoneDataPlugin(options = {}) {
         const file = cacheFile(tzdata, config, cacheDir);
         if (!file.exists) {
           try {
-            filterData(tzdata, config, file);
+            const filteredData = filterData(tzdata, config, file);
+            fs.writeFileSync(file.path, JSON.stringify(filteredData, null, 2));
           } catch (err) {
             console.warn(err); // eslint-disable-line no-console
             return; // Don't rewrite the request
@@ -193,3 +194,5 @@ function MomentTimezoneDataPlugin(options = {}) {
 }
 
 module.exports = MomentTimezoneDataPlugin;
+// Exported for testing purposes only
+module.exports.filterData = filterData;

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -2,7 +2,7 @@ const assert = require('power-assert');
 const del = require('del');
 const fs = require('fs');
 const findCacheDir = require('find-cache-dir');
-const { createMatchers, cacheDir } = require('../src/helpers');
+const { createMatchers, anyMatch, cacheDir } = require('../src/helpers');
 
 describe('createMatchers', () => {
   const testStrings = [
@@ -56,6 +56,27 @@ describe('createMatchers', () => {
     let matchers = createMatchers(1984);
     assertMatchers(matchers, 1, ['1984']);
   });
+});
+
+describe('anyMatch', () => {
+  const item = 'ABC';
+  const argList = [
+    // [name, matchers, result]
+    ['missing', undefined, true],
+    ['empty', [], true],
+    ['single RegExp', [/^A/], true],
+    ['many RegExps', [/^Z/, /\d/, /c$/i], true],
+    ['non-matching RegExps', [/^Z/, /\d/, /[D-H]/], false],
+  ];
+
+  for (let [name1, arg1, result1] of argList) {
+    for (let [name2, arg2, result2] of argList) {
+      let expected = result1 && result2;
+      it(`returns ${expected} with 1st matcher = ${name1}, 2nd matchers = ${name2}`, () => {
+        assert(anyMatch(item, arg1, arg2) === expected);
+      });
+    }
+  }
 });
 
 describe('cacheDir', () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -45,9 +45,9 @@ describe('createMatchers', () => {
     assert.deepEqual(matched, expectedMatches);
   }
 
-  it('when arg is empty, returns an empty array', () => {
+  it('when arg is empty, returns a "match everything" regexp', () => {
     let matchers = createMatchers();
-    assertMatchers(matchers, 0, []);
+    assertMatchers(matchers, 1, testStrings);
   });
 
   it('when arg is a regexp, returns array of original regexp', () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -2,7 +2,29 @@ const assert = require('power-assert');
 const del = require('del');
 const fs = require('fs');
 const findCacheDir = require('find-cache-dir');
-const { createMatchers, anyMatch, cacheDir } = require('../src/helpers');
+const { unique, createMatchers, anyMatch, cacheDir } = require('../src/helpers');
+
+describe('unique', () => {
+  it('returns empty array when a non-array is provided', () => {
+    assert.deepEqual(unique(), []);
+    assert.deepEqual(unique(null), []);
+    assert.deepEqual(unique({ a: 1, b: 2 }), []);
+  });
+
+  it('returns unique values for an array', () => {
+    assert.deepEqual(
+      unique([1, '1', 0, false, 1, 4, 0, 5]),
+      [1, '1', 0, false, 4, 5]
+    );
+  });
+
+  it('returns unique values for a string', () => {
+    assert.deepEqual(
+      unique('This is a string'),
+      ['T', 'h', 'i', 's', ' ', 'a', 't', 'r', 'n', 'g']
+    );
+  });
+});
 
 describe('createMatchers', () => {
   const testStrings = [
@@ -22,6 +44,11 @@ describe('createMatchers', () => {
     );
     assert.deepEqual(matched, expectedMatches);
   }
+
+  it('when arg is empty, returns an empty array', () => {
+    let matchers = createMatchers();
+    assertMatchers(matchers, 0, []);
+  });
 
   it('when arg is a regexp, returns array of original regexp', () => {
     let regexp = /s/i;

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -2,9 +2,9 @@ const assert = require('power-assert');
 const del = require('del');
 const fs = require('fs');
 const findCacheDir = require('find-cache-dir');
-const { createZoneMatchers, cacheDir } = require('../src/helpers');
+const { createMatchers, cacheDir } = require('../src/helpers');
 
-describe('createZoneMatchers', () => {
+describe('createMatchers', () => {
   const testStrings = [
     'EXACT TEXT',
     'exact text',
@@ -25,35 +25,35 @@ describe('createZoneMatchers', () => {
 
   it('when arg is a regexp, returns array of original regexp', () => {
     let regexp = /s/i;
-    let matchers = createZoneMatchers(regexp);
+    let matchers = createMatchers(regexp);
     assertMatchers(matchers, 1, ['CaSe sensitivE']);
     assert(matchers[0] === regexp);
   });
 
   it('when arg is a string, returns array of regexp exactly matching that string', () => {
-    let matchers = createZoneMatchers('exact text');
+    let matchers = createMatchers('exact text');
     assertMatchers(matchers, 1, ['exact text']);
   });
 
   it('when arg is array of all strings, returns array of regexp exactly matching strings', () => {
-    let matchers = createZoneMatchers(['1984', 'exact text', 'case sensitive']);
+    let matchers = createMatchers(['1984', 'exact text', 'case sensitive']);
     assertMatchers(matchers, 1, ['exact text', '1984']);
   });
 
   it('when arg is array of regexps, returns array of original regexps', () => {
     let regexp = /s/i;
-    let matchers = createZoneMatchers([regexp, /exact text/]);
+    let matchers = createMatchers([regexp, /exact text/]);
     assertMatchers(matchers, 2, ['exact text', 'inexact text example', 'CaSe sensitivE']);
     assert(matchers[0] === regexp);
   });
 
   it('when arg is array of mixed values, returns array of regexps', () => {
-    let matchers = createZoneMatchers(['EXACT TEXT', /e\s/, 'exact text']);
+    let matchers = createMatchers(['EXACT TEXT', /e\s/, 'exact text']);
     assertMatchers(matchers, 2, ['EXACT TEXT', 'exact text', 'CaSe sensitivE']);
   });
 
   it('when arg is not a string, returns array of regexp matching toString() value', () => {
-    let matchers = createZoneMatchers(1984);
+    let matchers = createMatchers(1984);
     assertMatchers(matchers, 1, ['1984']);
   });
 });

--- a/test/performance.js
+++ b/test/performance.js
@@ -1,0 +1,177 @@
+const moment = require('moment-timezone');
+const tzdata = require('moment-timezone/data/packed/latest.json');
+const { execSync } = require('child_process');
+const { PerformanceObserver, performance } = require('perf_hooks');
+const { filterData } = require('../src');
+const pkg = require('../package.json');
+
+let configs = [
+  {
+    name: 'single zone, all years',
+    options: {
+      matchZones: 'Europe/London',
+    },
+  },
+  {
+    name: 'single zone, 10 years',
+    options: {
+      matchZones: 'Europe/London',
+      startYear: 2015,
+      endYear: 2024,
+    },
+  },
+  {
+    name: 'single country, all years',
+    options: {
+      matchCountries: ['LI'],
+      matchZones: /./,
+    },
+  },
+  {
+    name: 'single country, 10 years',
+    options: {
+      matchCountries: ['LI'],
+      matchZones: /./,
+      startYear: 2015,
+      endYear: 2024,
+    },
+  },
+  {
+    name: 'all zones, all years',
+    options: {
+      matchZones: /./,
+    },
+  },
+  {
+    name: 'all zones, 10 years',
+    options: {
+      matchZones: /./,
+      startYear: 2015,
+      endYear: 2024,
+    },
+  },
+];
+
+// Remove country-based tests when running against older versions
+if (!tzdata.countries) {
+  configs = configs.filter(config => !config.options.matchCountries);
+}
+
+const runs = new Map();
+const runCount = 5;
+
+const obs = new PerformanceObserver((items) => {
+  const { name, duration } = items.getEntries()[0];
+  runs.get(name).push(duration);
+  performance.clearMarks();
+});
+obs.observe({ entryTypes: ['measure'] });
+
+const gitHash = execSync('git rev-parse --short HEAD');
+console.log(`
+Performance tests: version ${pkg.version}, moment-timezone ${moment.tz.version}, git hash ${gitHash}
+`);
+
+const queue = [];
+for (let i = 0; i < runCount; i++) {
+  configs.forEach(config => {
+    if (!runs.has(config.name)) {
+      runs.set(config.name, []);
+    }
+    queue.push(() => {
+      performance.mark('start');
+      filterData(tzdata, config.options);
+      performance.mark('end');
+      performance.measure(config.name, 'start', 'end');
+    });
+  });
+}
+
+const gap = 100;
+function doRun() {
+  const runFn = queue.shift();
+  runFn();
+  if (queue.length) {
+    setTimeout(doRun, gap);
+  } else {
+    report();
+  }
+}
+doRun();
+
+function round(num, digits) {
+  const exp = 10 ** digits;
+  return Math.round(num * exp) / exp;
+}
+
+const digitsLeft = 3;
+const digitsRight = 6;
+function tableNum(num) {
+  const rounded = round(num, digitsRight);
+  const [left, right] = String(rounded).split('.');
+  return `${left.padStart(digitsLeft)}.${right.padEnd(digitsRight)}`;
+}
+
+const longestNameLength = Math.max.apply(Math, configs.map(c => c.name.length));
+
+/**
+ * A simple custom replacement for console.table() that does better formatting of numbers
+ */
+function consoleTable(data) {
+  function dividerRow(startChar, midChar, endChar, fields) {
+    return (
+      startChar +
+      fields.map(f => '─'.repeat(f.width + 2)).join(midChar) +
+      endChar
+    );
+  }
+
+  function dataRow(rowValues) {
+    return `│ ${rowValues.join(' │ ')} │`;
+  }
+
+  // Width calculations
+  let fields = [{ name: 'test name', width: longestNameLength }];
+  const firstEntry = Object.values(data)[0];
+  for (let field of Object.keys(firstEntry)) {
+    fields.push({ name: field, width: digitsLeft + digitsRight + 1 });
+  }
+
+  // Header
+  console.log(dividerRow('┌', '┬', '┐', fields));
+  console.log(dataRow(fields.map(f => f.name.padEnd(f.width))));
+  console.log(dividerRow('├', '┼', '┤', fields));
+
+  // Body
+  for (let [testName, testData] of Object.entries(data)) {
+    let cells = [testName.padEnd(fields[0].width)];
+    for (let value of Object.values(testData)) {
+      cells.push(tableNum(value));
+    }
+    console.log(dataRow(cells));
+  }
+
+  // Footer
+  console.log(dividerRow('└', '┴', '┘', fields));
+}
+
+function report() {
+  let table = {};
+  for (let [name, times] of runs.entries()) {
+    let min = Math.min.apply(Math, times);
+    let max = Math.max.apply(Math, times);
+    let sum = times.reduce((a, t) => a + t, 0);
+    let avg = sum / times.length;
+    let sorted = times.slice().sort((a, b) => a - b);
+    let med = sorted[Math.floor(times.length / 2)];
+
+    table[name] = {
+      min,
+      max,
+      average: avg,
+      median: med,
+    };
+  }
+
+  consoleTable(table);
+}

--- a/test/performance.js
+++ b/test/performance.js
@@ -24,28 +24,23 @@ let configs = [
     name: 'single country, all years',
     options: {
       matchCountries: ['LI'],
-      matchZones: /./,
     },
   },
   {
     name: 'single country, 10 years',
     options: {
       matchCountries: ['LI'],
-      matchZones: /./,
       startYear: 2015,
       endYear: 2024,
     },
   },
   {
     name: 'all zones, all years',
-    options: {
-      matchZones: /./,
-    },
+    options: {},
   },
   {
     name: 'all zones, 10 years',
     options: {
-      matchZones: /./,
       startYear: 2015,
       endYear: 2024,
     },

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,7 +17,7 @@ function buildWebpack(options) {
     },
     plugins: [
       new MomentTimezoneDataPlugin(options),
-      new MomentLocalesPlugin(),
+      new MomentLocalesPlugin(), // Required for making tests faster
     ],
   });
   compiler.outputFileSystem = new MemoryFS();


### PR DESCRIPTION
Some minor performance optimisations following on from #24:

* Unpack and store all `links` and `countries` data up front, instead of doing it multiple fragmented times elsewhere.
* De-duplicate link and country zone names before creating RegExp matchers from them.
* Skip various filtering steps for `links` and `zones` when the `matchZones` option isn't provided, as they were effectively expensive no-ops.
* Use a `Map` to look up source zones for links, instead of searching an array every time.
* New separate testing script to keep track of performance across releases.